### PR TITLE
iteritems() -> items() for quick Python3 fix

### DIFF
--- a/templates/dellos6_ntp.j2
+++ b/templates/dellos6_ntp.j2
@@ -11,7 +11,7 @@ dellos_ntp:
 
 #####################################}
 {% if dellos_ntp is defined and dellos_ntp %}
-  {% for key,value in dellos_ntp.iteritems() %}
+  {% for key,value in dellos_ntp.items() %}
     {% if key == "server" and value %}
       {% for item in value %}
         {% if item.ip is defined and item.ip %}

--- a/templates/dellos9_ntp.j2
+++ b/templates/dellos9_ntp.j2
@@ -14,7 +14,7 @@ dellos_ntp:
 ###################################################}
 {% if dellos_ntp is defined and dellos_ntp %}
 
-{% for key,value in dellos_ntp.iteritems() %}
+{% for key,value in dellos_ntp.items() %}
   {% if key == "server" and value %}
     {% for item in value %}
       {% if item.ip is defined and item.ip %}


### PR DESCRIPTION
possible performance hit for large vars files
on Python2 but unlikely to impact most configs